### PR TITLE
Add AWS Redshift monitoring for errors, add the capability to create AWS CloudWatch alarms for all or specific AWS Lambda functions for failures and update README accordingly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ## Introduction
 
-AWS Failure Error Warning Termination Notification Framework is a framework for AWS cloud to notify for failures, errors, warnings and terminations for various AWS services.
+AWS Failure Error Warning Termination Notification Framework is a framework for AWS cloud to monitor resources for various AWS services and alert for failures, errors, warnings and terminations.
 
-You can update provided parameter values to enable or disable notification resources for different AWS services.
+You can update provided variable values to enable or disable notification resources for different AWS services.
 
 By default, all AWS services are disabled and you have to choose which one to enable.
 
@@ -27,14 +27,14 @@ Following are the AWS services for which you can enable notifications for failur
 -   `AWS CodePipeline (CP)`
 -   `AWS Config`
 -   `AWS Data Lifecycle Manager (DLM)`
--   `AWS DataSync (DS)`
 -   `AWS Database Migration Service (DMS)`
+-   `AWS DataSync (DS)`
 -   `AWS Elastic Block Store (EBS)`
 -   `AWS Elastic Compute Cloud (EC2) Auto Scaling`
 -   `AWS Elastic Compute Cloud (EC2)`
 -   `AWS Elastic Container Service (ECS)`
--   `AWS Elemental`
 -   `AWS Elastic Map Reduce (EMR)`
+-   `AWS Elemental`
 -   `AWS GameLift (GL)`
 -   `AWS Glue`
 -   `AWS Health`
@@ -43,12 +43,13 @@ Following are the AWS services for which you can enable notifications for failur
 -   `AWS Lambda`
 -   `AWS Macie`
 -   `AWS OpsWorks`
+-   `AWS Redshift`
 -   `AWS Relation Database Service (RDS)`
 -   `AWS SageMaker`
--   `AWS Signer`
 -   `AWS Server Migration Service (SMS)`
--   `AWS Systems Manager (SSM)`
+-   `AWS Signer`
 -   `AWS Step Functions (SF)`
+-   `AWS Systems Manager (SSM)`
 -   `AWS Transcribe`
 -   `AWS Trusted Advisor (TA)`
 
@@ -66,7 +67,7 @@ Following are the components used in this framework:
 -   AWS IAM role used by the Lambda function with least privileges.
 -   AWS Lambda Invoke Permission for AWS SNS topic.
 -   AWS CloudWatch events for the failures, errors, warnings and terminations notifications of various AWS services triggered upon events.
--   AWS CloudWatch alarm for the failures of AWS Lambda functions.
+-   AWS CloudWatch alarms for the failures of AWS Lambda functions.
 -   AWS RDS and DMS event subscriptions for the failures, errors, warnings and terminations of AWS RDS and DMS resources respectively.
 -   AWS SNS topic for receiving and sending notifications to the subscribed endpoint for AWS CloudFormation notifications.
 -   AWS SNS topic for receiving and sending notifications to the subscribed endpoint for failures, errors, warnings and terminations notifications of various AWS services.
@@ -78,8 +79,9 @@ Following are the components used in this framework:
 
 Following are the steps to successfully deploy and use this framework:
 -   Fork this repository from the master branch.
--   If you want to enable AWS CloudFormation failures notifications, change default value to `true` in the `variables.tf` file for `enable_cloudformation_failure_notification` parameter.
--   Similarly, for any AWS service you want to enable failures, errors, warnings and terminations notifications, change default value to `true` for that AWS service's parameter that is starting with `enable_...`
+-   If you want to enable AWS CloudFormation failures notifications, change default value to `true` for `enable_cloudformation_failure_notification` variable.
+-   Similarly, for any AWS service you want to enable failures, errors, warnings and terminations notifications, change default value to `true` for that AWS service's variable that is starting with `enable_...`
+-   If `enable_lambda_failure_notification` variable is set to to `true` for AWS Lambda functions failure notifications, you can set a list of specific AWS Lambda functions to enable monitoring only for those using `lambda_function_names` variable. Otherwise, it will fetch all AWS Lambda function names.
 -   Configure AWS CLI and then run `terraform init` and then `terraform apply` within the `/terraform` directory and provide protocol (e.g., `email` or `https`) and endpoint (e.g., `abcxyz@gmail.com`) by providing values for `failure_error_warning_termination_notification_sns_topic_protocol` and `failure_error_warning_termination_notification_sns_topic_endpoint` respectively.
 -   If the Terraform change plan looks good, enter `yes` to create the resources.
 -   Wait for the Terraform to finish creating all the resources.
@@ -99,7 +101,7 @@ Following are the steps to successfully deploy and use this framework:
 -   If you want to enable AWS CloudFormation failures notifications, select `YES` for `EnableCloudFormationFailureNotification` and then specify the following:
     -   Enter `CloudFormationFailureLambdaCodeS3Bucket` which is an AWS S3 Bucket Name having AWS CloudFormation Failure Notification AWS Lambda Function Code. (e.g., my-bucket).
     -   Enter `CloudFormationFailureLambdaCodeS3Key` which is an AWS S3 Bucket Key having AWS CloudFormation Failure Notification AWS Lambda Function Code (e.g., lambda/code/aws_cloudformation_failure_notification.zip).
--   Similarly, for any AWS service you want to enable failures, errors, warnings and terminations notifications, select `YES` for that AWS service's parameter that is starting with `Enable...`
+-   Similarly, for any AWS service you want to enable failures, errors, warnings and terminations notifications, select `YES` for that AWS service's variable that is starting with `Enable...`
 -   Enter suitable `Tags` if required.
 -   Under `Review`, select `I acknowledge that AWS CloudFormation might create IAM resources with custom names.` and click create.
 -   Wait for the stack to change its `Status` to `CREATE_COMPLETE`.

--- a/aws_failure_error_warning_termination_notification_framework_cft.json
+++ b/aws_failure_error_warning_termination_notification_framework_cft.json
@@ -2,19 +2,22 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "AWS CloudFormation Template to deploy the Failure, Error, Warning and Termination Notification Framework. You will be billed for the AWS resources used if you create a stack from this template.",
   "Parameters": {
-    "FailureErrorWarningTerminationNotificationSNSTopicProtocol": {
-      "Description": "Protocol for AWS Failure, Error, Warning and Termination Notification SNS Topic.",
-      "Type": "String"
-    },
     "FailureErrorWarningTerminationNotificationSNSTopicEndpoint": {
       "Description": "Endpoint for AWS Failure, Error, Warning and Termination Notification SNS Topic.",
+      "Type": "String"
+    },
+    "FailureErrorWarningTerminationNotificationSNSTopicProtocol": {
+      "Description": "Protocol for AWS Failure, Error, Warning and Termination Notification SNS Topic.",
       "Type": "String"
     },
     "EnableCloudFormationFailureNotification": {
       "Description": "Option to Enable AWS CloudFormation Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "CloudFormationFailureLambdaCodeS3Bucket": {
@@ -31,446 +34,747 @@
       "Description": "Option to Enable AWS Lambda Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableDMSFailureWarningNotification": {
       "Description": "Option to Enable AWS DMS Failure and Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableRDSFailureWarningNotification": {
       "Description": "Option to Enable AWS RDS Failure and Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
+      "ConstraintDescription": "Select 'YES' or 'NO'"
+    },
+    "EnableRedshiftErrorNotification": {
+      "Description": "Option to Enable AWS Redshift Error Notification.",
+      "Type": "String",
+      "Default": "YES",
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableCodeBuildFailureNotification": {
       "Description": "Option to Enable AWS CodeBuild Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableEC2AutoScalingFailureNotification": {
       "Description": "Option to Enable AWS EC2 Auto Scaling Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableBatchFailureNotification": {
       "Description": "Option to Enable AWS Batch Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableCodeDeployFailureNotification": {
       "Description": "Option to Enable AWS CodeDeploy Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableCodePipelineFailureNotification": {
       "Description": "Option to Enable AWS CodePipeline Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableConfigFailureNotification": {
       "Description": "Option to Enable AWS Config Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableEBSFailureNotification": {
       "Description": "Option to Enable AWS EBS Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableGlueFailureNotification": {
       "Description": "Option to Enable AWS Glue Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableEMRFailureNotification": {
       "Description": "Option to Enable AWS EMR Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableEMRErrorNotification": {
       "Description": "Option to Enable AWS EMR Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableECSInstanceTerminationNotification": {
       "Description": "Option to Enable AWS ECS Instance Termination Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableECSTaskTerminationNotification": {
       "Description": "Option to Enable AWS ECS Task Termination Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableEC2InstanceTerminationNotification": {
       "Description": "Option to Enable AWS EC2 Instance Termination Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableEC2SpotInstanceErrorNotification": {
       "Description": "Option to Enable AWS EC2 Spot Instance Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableTrustedAdvisorErrorWarningNotification": {
       "Description": "Option to Enable AWS Trusted Advisor Error and Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableHealthErrorNotification": {
       "Description": "Option to Enable AWS Health Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSMSFailureNotification": {
       "Description": "Option to Enable AWS Server Migration Service Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableStepFunctionsFailureNotification": {
       "Description": "Option to Enable AWS Step Functions Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSSMMaintainanceWindowFailureNotification": {
       "Description": "Option to Enable AWS SSM Maintainance Window Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSSMEC2FailureNotification": {
       "Description": "Option to Enable AWS SSM EC2 State Manager, Run Command and Automation Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSSMComplianceWarningNotification": {
       "Description": "Option to Enable AWS SSM Compliance Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableOpsWorksFailureNotification": {
       "Description": "Option to Enable AWS OpsWorks Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableOpsWorksErrorNotification": {
       "Description": "Option to Enable AWS OpsWorks Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableKMSKeyExpirationWarningNotification": {
       "Description": "Option to Enable AWS KMS Key Expiration Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableMacieWarningNotification": {
       "Description": "Option to Enable AWS Macie Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableGameLiftFailureNotification": {
       "Description": "Option to Enable AWS GameLift Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableTranscribeFailureNotification": {
       "Description": "Option to Enable AWS Transcribe Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSignerFailureNotification": {
       "Description": "Option to Enable AWS Signer Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableDataSyncErrorWarningNotification": {
       "Description": "Option to Enable AWS DataSync Error and Warning Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableIoTAnalyticsFailureNotification": {
       "Description": "Option to Enable AWS IoT Analytics Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableDataLifecycleManagerErrorNotification": {
       "Description": "Option to Enable AWS Data Lifecycle Manager Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableElementalMediaPackageErrorNotification": {
       "Description": "Option to Enable AWS Elemental MediaPackage Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableElementalMediaLiveErrorNotification": {
       "Description": "Option to Enable AWS Elemental MediaLive Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableElementalMediaConvertErrorNotification": {
       "Description": "Option to Enable AWS Elemental MediaConvert Error Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSageMakerHyperParameterTuningFailureNotification": {
       "Description": "Option to Enable AWS SageMaker HyperParameter Tuning Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSageMakerTransformFailureNotification": {
       "Description": "Option to Enable AWS SageMaker Transform Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     },
     "EnableSageMakerTrainingFailureNotification": {
       "Description": "Option to Enable AWS SageMaker Training Failure Notification.",
       "Type": "String",
       "Default": "YES",
-      "AllowedValues": ["YES", "NO"],
+      "AllowedValues": [
+        "YES",
+        "NO"
+      ],
       "ConstraintDescription": "Select 'YES' or 'NO'"
     }
   },
   "Conditions": {
     "CreateCloudFormationFailureResources": {
       "Fn::Equals": [
-        { "Ref": "EnableCloudFormationFailureNotification" },
+        {
+          "Ref": "EnableCloudFormationFailureNotification"
+        },
         "YES"
       ]
     },
     "CreateLambdaFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableLambdaFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableLambdaFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateDMSFailureWarningResources": {
-      "Fn::Equals": [{ "Ref": "EnableDMSFailureWarningNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableDMSFailureWarningNotification"
+        },
+        "YES"
+      ]
     },
     "CreateRDSFailureWarningResources": {
-      "Fn::Equals": [{ "Ref": "EnableRDSFailureWarningNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableRDSFailureWarningNotification"
+        },
+        "YES"
+      ]
+    },
+    "CreateRedshiftErrorResources": {
+      "Fn::Equals": [
+        {
+          "Ref": "EnableRedshiftErrorNotification"
+        },
+        "YES"
+      ]
     },
     "CreateCBFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableCodeBuildFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableCodeBuildFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateEC2AutoScalingFailureResources": {
       "Fn::Equals": [
-        { "Ref": "EnableEC2AutoScalingFailureNotification" },
+        {
+          "Ref": "EnableEC2AutoScalingFailureNotification"
+        },
         "YES"
       ]
     },
     "CreateBatchFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableBatchFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableBatchFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateCodeDeployFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableCodeDeployFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableCodeDeployFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateCodePipelineFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableCodePipelineFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableCodePipelineFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateConfigFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableConfigFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableConfigFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateEBSFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableEBSFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableEBSFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateGlueFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableGlueFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableGlueFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateEMRFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableEMRFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableEMRFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateEMRErrorResources": {
-      "Fn::Equals": [{ "Ref": "EnableEMRErrorNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableEMRErrorNotification"
+        },
+        "YES"
+      ]
     },
     "CreateECSInstanceTerminationResources": {
       "Fn::Equals": [
-        { "Ref": "EnableECSInstanceTerminationNotification" },
+        {
+          "Ref": "EnableECSInstanceTerminationNotification"
+        },
         "YES"
       ]
     },
     "CreateECSTaskTerminationResources": {
-      "Fn::Equals": [{ "Ref": "EnableECSTaskTerminationNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableECSTaskTerminationNotification"
+        },
+        "YES"
+      ]
     },
     "CreateEC2InstanceTerminationResources": {
       "Fn::Equals": [
-        { "Ref": "EnableEC2InstanceTerminationNotification" },
+        {
+          "Ref": "EnableEC2InstanceTerminationNotification"
+        },
         "YES"
       ]
     },
     "CreateEC2SpotInstanceErrorResources": {
-      "Fn::Equals": [{ "Ref": "EnableEC2SpotInstanceErrorNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableEC2SpotInstanceErrorNotification"
+        },
+        "YES"
+      ]
     },
     "CreateTrustedAdvisorErrorWarningResources": {
       "Fn::Equals": [
-        { "Ref": "EnableTrustedAdvisorErrorWarningNotification" },
+        {
+          "Ref": "EnableTrustedAdvisorErrorWarningNotification"
+        },
         "YES"
       ]
     },
     "CreateHealthErrorResources": {
-      "Fn::Equals": [{ "Ref": "EnableHealthErrorNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableHealthErrorNotification"
+        },
+        "YES"
+      ]
     },
     "CreateSMSFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableSMSFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableSMSFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateStepFunctionsFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableStepFunctionsFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableStepFunctionsFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateSSMMaintainanceWindowFailureResources": {
       "Fn::Equals": [
-        { "Ref": "EnableSSMMaintainanceWindowFailureNotification" },
+        {
+          "Ref": "EnableSSMMaintainanceWindowFailureNotification"
+        },
         "YES"
       ]
     },
     "CreateSSMEC2FailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableSSMEC2FailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableSSMEC2FailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateSSMComplianceWarningResources": {
-      "Fn::Equals": [{ "Ref": "EnableSSMComplianceWarningNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableSSMComplianceWarningNotification"
+        },
+        "YES"
+      ]
     },
     "CreateOpsWorksFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableOpsWorksFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableOpsWorksFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateOpsWorksErrorResources": {
-      "Fn::Equals": [{ "Ref": "EnableOpsWorksErrorNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableOpsWorksErrorNotification"
+        },
+        "YES"
+      ]
     },
     "CreateKMSKeyExpirationWarningResources": {
       "Fn::Equals": [
-        { "Ref": "EnableKMSKeyExpirationWarningNotification" },
+        {
+          "Ref": "EnableKMSKeyExpirationWarningNotification"
+        },
         "YES"
       ]
     },
     "CreateMacieWarningResources": {
-      "Fn::Equals": [{ "Ref": "EnableMacieWarningNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableMacieWarningNotification"
+        },
+        "YES"
+      ]
     },
     "CreateGameLiftFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableGameLiftFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableGameLiftFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateTranscribeFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableTranscribeFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableTranscribeFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateSignerFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableSignerFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableSignerFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateDataSyncErrorWarningResources": {
-      "Fn::Equals": [{ "Ref": "EnableDataSyncErrorWarningNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableDataSyncErrorWarningNotification"
+        },
+        "YES"
+      ]
     },
     "CreateIoTAnalyticsFailureResources": {
-      "Fn::Equals": [{ "Ref": "EnableIoTAnalyticsFailureNotification" }, "YES"]
+      "Fn::Equals": [
+        {
+          "Ref": "EnableIoTAnalyticsFailureNotification"
+        },
+        "YES"
+      ]
     },
     "CreateDataLifecycleManagerErrorResources": {
       "Fn::Equals": [
-        { "Ref": "EnableDataLifecycleManagerErrorNotification" },
+        {
+          "Ref": "EnableDataLifecycleManagerErrorNotification"
+        },
         "YES"
       ]
     },
     "CreateElementalMediaPackageErrorResources": {
       "Fn::Equals": [
-        { "Ref": "EnableElementalMediaPackageErrorNotification" },
+        {
+          "Ref": "EnableElementalMediaPackageErrorNotification"
+        },
         "YES"
       ]
     },
     "CreateElementalMediaLiveErrorResources": {
       "Fn::Equals": [
-        { "Ref": "EnableElementalMediaLiveErrorNotification" },
+        {
+          "Ref": "EnableElementalMediaLiveErrorNotification"
+        },
         "YES"
       ]
     },
     "CreateElementalMediaConvertErrorResources": {
       "Fn::Equals": [
-        { "Ref": "EnableElementalMediaConvertErrorNotification" },
+        {
+          "Ref": "EnableElementalMediaConvertErrorNotification"
+        },
         "YES"
       ]
     },
     "CreateSageMakerHyperParameterTuningFailureResources": {
       "Fn::Equals": [
-        { "Ref": "EnableSageMakerHyperParameterTuningFailureNotification" },
+        {
+          "Ref": "EnableSageMakerHyperParameterTuningFailureNotification"
+        },
         "YES"
       ]
     },
     "CreateSageMakerTransformFailureResources": {
       "Fn::Equals": [
-        { "Ref": "EnableSageMakerTransformFailureNotification" },
+        {
+          "Ref": "EnableSageMakerTransformFailureNotification"
+        },
         "YES"
       ]
     },
     "CreateSageMakerTrainingFailureResources": {
       "Fn::Equals": [
-        { "Ref": "EnableSageMakerTrainingFailureNotification" },
+        {
+          "Ref": "EnableSageMakerTrainingFailureNotification"
+        },
         "YES"
       ]
     }
@@ -542,7 +846,9 @@
                   "s3.amazonaws.com"
                 ]
               },
-              "Action": ["SNS:Publish"],
+              "Action": [
+                "SNS:Publish"
+              ],
               "Resource": {
                 "Ref": "FailureNotificationSNSTopic"
               }
@@ -619,7 +925,10 @@
         },
         "Handler": "aws_cloudformation_failure_notification.lambda_handler",
         "Role": {
-          "Fn::GetAtt": ["CloudFormationFailureLambdaIAMRole", "Arn"]
+          "Fn::GetAtt": [
+            "CloudFormationFailureLambdaIAMRole",
+            "Arn"
+          ]
         },
         "Runtime": "python3.9",
         "Timeout": 60,
@@ -640,7 +949,10 @@
         "Subscription": [
           {
             "Endpoint": {
-              "Fn::GetAtt": ["CloudFormationFailureLambdaFunction", "Arn"]
+              "Fn::GetAtt": [
+                "CloudFormationFailureLambdaFunction",
+                "Arn"
+              ]
             },
             "Protocol": "lambda"
           }
@@ -687,9 +999,13 @@
               "Sid": "Sid2",
               "Effect": "Allow",
               "Principal": {
-                "Service": ["cloudformation.amazonaws.com"]
+                "Service": [
+                  "cloudformation.amazonaws.com"
+                ]
               },
-              "Action": ["SNS:Publish"],
+              "Action": [
+                "SNS:Publish"
+              ],
               "Resource": {
                 "Ref": "CFNotificationSNSTopic"
               }
@@ -708,7 +1024,10 @@
       "Condition": "CreateCloudFormationFailureResources",
       "Properties": {
         "FunctionName": {
-          "Fn::GetAtt": ["CloudFormationFailureLambdaFunction", "Arn"]
+          "Fn::GetAtt": [
+            "CloudFormationFailureLambdaFunction",
+            "Arn"
+          ]
         },
         "Action": "lambda:InvokeFunction",
         "Principal": "sns.amazonaws.com",
@@ -729,7 +1048,7 @@
         "DatapointsToAlarm": 1,
         "Statistic": "Sum",
         "ComparisonOperator": "GreaterThanThreshold",
-        "Threshold": 0.0,
+        "Threshold": 0,
         "Period": 60,
         "EvaluationPeriods": 1,
         "AlarmActions": [
@@ -744,7 +1063,12 @@
       "Condition": "CreateDMSFailureWarningResources",
       "Properties": {
         "SubscriptionName": "dms-instance-failure-warning-event",
-        "EventCategories": ["failure", "low storage", "failover", "deletion"],
+        "EventCategories": [
+          "failure",
+          "low storage",
+          "failover",
+          "deletion"
+        ],
         "SnsTopicArn": {
           "Ref": "FailureNotificationSNSTopic"
         },
@@ -762,7 +1086,10 @@
       "Condition": "CreateDMSFailureWarningResources",
       "Properties": {
         "SubscriptionName": "dms-task-failure-event",
-        "EventCategories": ["failure", "deletion"],
+        "EventCategories": [
+          "failure",
+          "deletion"
+        ],
         "SnsTopicArn": {
           "Ref": "FailureNotificationSNSTopic"
         },
@@ -797,7 +1124,9 @@
       "Type": "AWS::RDS::EventSubscription",
       "Condition": "CreateRDSFailureWarningResources",
       "Properties": {
-        "EventCategories": ["failure"],
+        "EventCategories": [
+          "failure"
+        ],
         "SnsTopicArn": {
           "Ref": "FailureNotificationSNSTopic"
         },
@@ -808,7 +1137,9 @@
       "Type": "AWS::RDS::EventSubscription",
       "Condition": "CreateRDSFailureWarningResources",
       "Properties": {
-        "EventCategories": ["notification"],
+        "EventCategories": [
+          "notification"
+        ],
         "SnsTopicArn": {
           "Ref": "FailureNotificationSNSTopic"
         },
@@ -819,11 +1150,80 @@
       "Type": "AWS::RDS::EventSubscription",
       "Condition": "CreateRDSFailureWarningResources",
       "Properties": {
-        "EventCategories": ["failure", "failover", "notification"],
+        "EventCategories": [
+          "failure",
+          "failover",
+          "notification"
+        ],
         "SnsTopicArn": {
           "Ref": "FailureNotificationSNSTopic"
         },
         "SourceType": "db-cluster"
+      }
+    },
+    "RedshiftClusterErrorEvent": {
+      "Type": "AWS::Redshift::EventSubscription",
+      "Condition": "CreateRedshiftErrorResources",
+      "Properties": {
+        "Enabled": true,
+        "Severity": "ERROR",
+        "SnsTopicArn": {
+          "Ref": "FailureNotificationSNSTopic"
+        },
+        "SourceType": "cluster",
+        "SubscriptionName": "aws-redshift-event-subscription-cluster-error-event"
+      }
+    },
+    "RedshiftClusterParameterGroupErrorEvent": {
+      "Type": "AWS::Redshift::EventSubscription",
+      "Condition": "CreateRedshiftErrorResources",
+      "Properties": {
+        "Enabled": true,
+        "Severity": "ERROR",
+        "SnsTopicArn": {
+          "Ref": "FailureNotificationSNSTopic"
+        },
+        "SourceType": "cluster-parameter-group",
+        "SubscriptionName": "aws-redshift-event-subscription-cluster-parameter-group-error-event"
+      }
+    },
+    "RedshiftClusterSecurityGroupErrorEvent": {
+      "Type": "AWS::Redshift::EventSubscription",
+      "Condition": "CreateRedshiftErrorResources",
+      "Properties": {
+        "Enabled": true,
+        "Severity": "ERROR",
+        "SnsTopicArn": {
+          "Ref": "FailureNotificationSNSTopic"
+        },
+        "SourceType": "cluster-security-group",
+        "SubscriptionName": "aws-redshift-event-subscription-cluster-security-group-error-event"
+      }
+    },
+    "RedshiftClusterSnapshotErrorEvent": {
+      "Type": "AWS::Redshift::EventSubscription",
+      "Condition": "CreateRedshiftErrorResources",
+      "Properties": {
+        "Enabled": true,
+        "Severity": "ERROR",
+        "SnsTopicArn": {
+          "Ref": "FailureNotificationSNSTopic"
+        },
+        "SourceType": "cluster-snapshot",
+        "SubscriptionName": "aws-redshift-event-subscription-cluster-snapshot-error-event"
+      }
+    },
+    "RedshiftScheduledActionErrorEvent": {
+      "Type": "AWS::Redshift::EventSubscription",
+      "Condition": "CreateRedshiftErrorResources",
+      "Properties": {
+        "Enabled": true,
+        "Severity": "ERROR",
+        "SnsTopicArn": {
+          "Ref": "FailureNotificationSNSTopic"
+        },
+        "SourceType": "scheduled-action",
+        "SubscriptionName": "aws-redshift-event-subscription-scheduled-action-error-event"
       }
     },
     "CBFailureCloudWatchEvent": {
@@ -833,10 +1233,16 @@
         "Name": "cb-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS CodeBuild Failures.",
         "EventPattern": {
-          "source": ["aws.codebuild"],
-          "detail-type": ["CodeBuild Build State Change"],
+          "source": [
+            "aws.codebuild"
+          ],
+          "detail-type": [
+            "CodeBuild Build State Change"
+          ],
           "detail": {
-            "build-status": ["FAILED"]
+            "build-status": [
+              "FAILED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -868,7 +1274,9 @@
         "Name": "ec2-autoscaling-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS EC2 Auto Scaling Failures.",
         "EventPattern": {
-          "source": ["aws.autoscaling"],
+          "source": [
+            "aws.autoscaling"
+          ],
           "detail-type": [
             "EC2 Instance Launch Unsuccessful",
             "EC2 Instance Terminate Unsuccessful"
@@ -903,10 +1311,16 @@
         "Name": "batch-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Batch Failures.",
         "EventPattern": {
-          "source": ["aws.batch"],
-          "detail-type": ["Batch Job State Change"],
+          "source": [
+            "aws.batch"
+          ],
+          "detail-type": [
+            "Batch Job State Change"
+          ],
           "detail": {
-            "status": ["FAILED"]
+            "status": [
+              "FAILED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -938,13 +1352,17 @@
         "Name": "codedeploy-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS CodeDeploy Failures.",
         "EventPattern": {
-          "source": ["aws.codedeploy"],
+          "source": [
+            "aws.codedeploy"
+          ],
           "detail-type": [
             "CodeDeploy Deployment State-change Notification",
             "CodeDeploy Instance State-change Notification"
           ],
           "detail": {
-            "state": ["FAILURE"]
+            "state": [
+              "FAILURE"
+            ]
           }
         },
         "State": "ENABLED",
@@ -976,10 +1394,17 @@
         "Name": "codepipeline-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS CodePipeline Failures.",
         "EventPattern": {
-          "source": ["aws.codepipeline"],
-          "detail-type": ["CodePipeline Pipeline Execution State Change"],
+          "source": [
+            "aws.codepipeline"
+          ],
+          "detail-type": [
+            "CodePipeline Pipeline Execution State Change"
+          ],
           "detail": {
-            "state": ["CANCELED", "FAILED"]
+            "state": [
+              "CANCELED",
+              "FAILED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1011,10 +1436,16 @@
         "Name": "config-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Config Failures.",
         "EventPattern": {
-          "source": ["aws.config"],
-          "detail-type": ["Config Configuration Snapshot Delivery Status"],
+          "source": [
+            "aws.config"
+          ],
+          "detail-type": [
+            "Config Configuration Snapshot Delivery Status"
+          ],
           "detail": {
-            "messageType": ["ConfigurationSnapshotDeliveryFailed"]
+            "messageType": [
+              "ConfigurationSnapshotDeliveryFailed"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1046,7 +1477,9 @@
         "Name": "ebs-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS EBS Failures.",
         "EventPattern": {
-          "source": ["aws.ec2"],
+          "source": [
+            "aws.ec2"
+          ],
           "detail-type": [
             "EBS Snapshot Notification",
             "EBS Multi-Volume Snapshots Completion Status",
@@ -1062,7 +1495,9 @@
               "modifyVolume",
               "reattachVolume"
             ],
-            "result": ["failed"]
+            "result": [
+              "failed"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1094,10 +1529,18 @@
         "Name": "glue-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Glue Failures.",
         "EventPattern": {
-          "source": ["aws.glue"],
-          "detail-type": ["Glue Crawler State Change", "Glue Job State Change"],
+          "source": [
+            "aws.glue"
+          ],
+          "detail-type": [
+            "Glue Crawler State Change",
+            "Glue Job State Change"
+          ],
           "detail": {
-            "state": ["FAILED", "TIMEOUT"]
+            "state": [
+              "FAILED",
+              "TIMEOUT"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1129,7 +1572,9 @@
         "Name": "emr-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS EMR Failures.",
         "EventPattern": {
-          "source": ["aws.emr"],
+          "source": [
+            "aws.emr"
+          ],
           "detail-type": [
             "EMR Instance Fleet State Change",
             "EMR Auto Scaling Policy State Change",
@@ -1175,8 +1620,12 @@
         "Name": "emr-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS EMR Errors.",
         "EventPattern": {
-          "source": ["aws.emr"],
-          "detail-type": ["EMR Configuration Error"]
+          "source": [
+            "aws.emr"
+          ],
+          "detail-type": [
+            "EMR Configuration Error"
+          ]
         },
         "State": "ENABLED",
         "Targets": [
@@ -1207,10 +1656,16 @@
         "Name": "ecs-instance-termination-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS ECS Instance Terminations.",
         "EventPattern": {
-          "source": ["aws.ecs"],
-          "detail-type": ["ECS Container Instance State Change"],
+          "source": [
+            "aws.ecs"
+          ],
+          "detail-type": [
+            "ECS Container Instance State Change"
+          ],
           "detail": {
-            "status": ["STOPPED"]
+            "status": [
+              "STOPPED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1242,10 +1697,16 @@
         "Name": "ecs-task-termination-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS ECS Task Terminations.",
         "EventPattern": {
-          "source": ["aws.ecs"],
-          "detail-type": ["ECS Task State Change"],
+          "source": [
+            "aws.ecs"
+          ],
+          "detail-type": [
+            "ECS Task State Change"
+          ],
           "detail": {
-            "status": ["STOPPED"]
+            "status": [
+              "STOPPED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1277,10 +1738,17 @@
         "Name": "ec2-instance-termination-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS EC2 Instance Terminations.",
         "EventPattern": {
-          "source": ["aws.ec2"],
-          "detail-type": ["EC2 Instance State-change Notification"],
+          "source": [
+            "aws.ec2"
+          ],
+          "detail-type": [
+            "EC2 Instance State-change Notification"
+          ],
           "detail": {
-            "state": ["stopping", "shutting-down"]
+            "state": [
+              "stopping",
+              "shutting-down"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1312,8 +1780,12 @@
         "Name": "ec2-spot-instance-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS EC2 Spot Instance Errors.",
         "EventPattern": {
-          "source": ["aws.ec2"],
-          "detail-type": ["EC2 Spot Instance Interruption Warning"]
+          "source": [
+            "aws.ec2"
+          ],
+          "detail-type": [
+            "EC2 Spot Instance Interruption Warning"
+          ]
         },
         "State": "ENABLED",
         "Targets": [
@@ -1344,10 +1816,17 @@
         "Name": "trusted-advisor-error-warning-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Trusted Advisor Errors and Warnings.",
         "EventPattern": {
-          "source": ["aws.trustedadvisor"],
-          "detail-type": ["Trusted Advisor Check Item Refresh Notification"],
+          "source": [
+            "aws.trustedadvisor"
+          ],
+          "detail-type": [
+            "Trusted Advisor Check Item Refresh Notification"
+          ],
           "detail": {
-            "status": ["ERROR", "WARN"]
+            "status": [
+              "ERROR",
+              "WARN"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1379,10 +1858,17 @@
         "Name": "health-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Health Errors.",
         "EventPattern": {
-          "source": ["aws.health"],
-          "detail-type": ["AWS Health Event", "AWS Health Abuse Event"],
+          "source": [
+            "aws.health"
+          ],
+          "detail-type": [
+            "AWS Health Event",
+            "AWS Health Abuse Event"
+          ],
           "detail": {
-            "eventTypeCategory": ["issue"]
+            "eventTypeCategory": [
+              "issue"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1414,10 +1900,16 @@
         "Name": "sms-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SMS Failures.",
         "EventPattern": {
-          "source": ["aws.sms"],
-          "detail-type": ["Server Migration Job State Change"],
+          "source": [
+            "aws.sms"
+          ],
+          "detail-type": [
+            "Server Migration Job State Change"
+          ],
           "detail": {
-            "state": ["Failed"]
+            "state": [
+              "Failed"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1449,10 +1941,18 @@
         "Name": "step-functions-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Step Functions Failures.",
         "EventPattern": {
-          "source": ["aws.states"],
-          "detail-type": ["Step Functions Execution Status Change"],
+          "source": [
+            "aws.states"
+          ],
+          "detail-type": [
+            "Step Functions Execution Status Change"
+          ],
           "detail": {
-            "status": ["ABORTED", "FAILED", "TIMED_OUT"]
+            "status": [
+              "ABORTED",
+              "FAILED",
+              "TIMED_OUT"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1484,14 +1984,20 @@
         "Name": "ssm-maintainance-window-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SSM Maintainance Window Failures.",
         "EventPattern": {
-          "source": ["aws.ssm"],
+          "source": [
+            "aws.ssm"
+          ],
           "detail-type": [
             "Maintenance Window Execution State-change Notification",
             "Maintenance Window Task Execution State-change Notification",
             "Maintenance Window Task Target Invocation State-change Notification"
           ],
           "detail": {
-            "status": ["CANCELLED", "FAILED", "TIMED_OUT"]
+            "status": [
+              "CANCELLED",
+              "FAILED",
+              "TIMED_OUT"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1523,7 +2029,9 @@
         "Name": "ssm-ec2-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SSM EC2 State Manager, Run Command and Automation Failures.",
         "EventPattern": {
-          "source": ["aws.ssm"],
+          "source": [
+            "aws.ssm"
+          ],
           "detail-type": [
             "EC2 State Manager Association State Change",
             "EC2 State Manager Instance Association State Change",
@@ -1533,7 +2041,11 @@
             "EC2 Automation Execution Status-change Notification"
           ],
           "detail": {
-            "status": ["Failed", "Cancelled", "TimedOut"]
+            "status": [
+              "Failed",
+              "Cancelled",
+              "TimedOut"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1565,10 +2077,16 @@
         "Name": "ssm-compliance-warning-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SSM Compliance Warnings.",
         "EventPattern": {
-          "source": ["aws.ssm"],
-          "detail-type": ["Configuration Compliance State Change"],
+          "source": [
+            "aws.ssm"
+          ],
+          "detail-type": [
+            "Configuration Compliance State Change"
+          ],
           "detail": {
-            "compliance-status": ["non_compliant"]
+            "compliance-status": [
+              "non_compliant"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1600,7 +2118,9 @@
         "Name": "opsworks-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS OpsWorks Failures.",
         "EventPattern": {
-          "source": ["aws.opsworks"],
+          "source": [
+            "aws.opsworks"
+          ],
           "detail-type": [
             "OpsWorks Command State Change",
             "OpsWorks Instance State Change",
@@ -1650,8 +2170,12 @@
         "Name": "opsworks-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS OpsWorks Errors.",
         "EventPattern": {
-          "source": ["aws.opsworks"],
-          "detail-type": ["OpsWorks Alert"]
+          "source": [
+            "aws.opsworks"
+          ],
+          "detail-type": [
+            "OpsWorks Alert"
+          ]
         },
         "State": "ENABLED",
         "Targets": [
@@ -1682,8 +2206,12 @@
         "Name": "kms-key-expiration-warning-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS KMS Key Expiration Warnings.",
         "EventPattern": {
-          "source": ["aws.kms"],
-          "detail-type": ["KMS Imported Key Material Expiration"]
+          "source": [
+            "aws.kms"
+          ],
+          "detail-type": [
+            "KMS Imported Key Material Expiration"
+          ]
         },
         "State": "ENABLED",
         "Targets": [
@@ -1714,8 +2242,12 @@
         "Name": "macie-warning-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Macie Warnings.",
         "EventPattern": {
-          "source": ["aws.macie"],
-          "detail-type": ["Macie Alert"]
+          "source": [
+            "aws.macie"
+          ],
+          "detail-type": [
+            "Macie Alert"
+          ]
         },
         "State": "ENABLED",
         "Targets": [
@@ -1746,8 +2278,12 @@
         "Name": "gamelift-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS GameLift Failures.",
         "EventPattern": {
-          "source": ["aws.gamelift"],
-          "detail-type": ["GameLift Matchmaking Event"],
+          "source": [
+            "aws.gamelift"
+          ],
+          "detail-type": [
+            "GameLift Matchmaking Event"
+          ],
           "detail": {
             "type": [
               "MatchmakingTimedOut",
@@ -1785,10 +2321,16 @@
         "Name": "transcribe-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Transcribe Failures.",
         "EventPattern": {
-          "source": ["aws.transcribe"],
-          "detail-type": ["Transcribe Job State Change"],
+          "source": [
+            "aws.transcribe"
+          ],
+          "detail-type": [
+            "Transcribe Job State Change"
+          ],
           "detail": {
-            "TranscriptionJobStatus": ["FAILED"]
+            "TranscriptionJobStatus": [
+              "FAILED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1820,10 +2362,16 @@
         "Name": "signer-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Signer Failures.",
         "EventPattern": {
-          "source": ["aws.signer"],
-          "detail-type": ["Signer Job Status Change"],
+          "source": [
+            "aws.signer"
+          ],
+          "detail-type": [
+            "Signer Job Status Change"
+          ],
           "detail": {
-            "status": ["Failed"]
+            "status": [
+              "Failed"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1855,14 +2403,20 @@
         "Name": "datasync-error-warning-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS DataSync Errors and Warnings.",
         "EventPattern": {
-          "source": ["aws.datasync"],
+          "source": [
+            "aws.datasync"
+          ],
           "detail-type": [
             "DataSync Task Execution State Change",
             "DataSync Task State Change",
             "DataSync Agent State Change"
           ],
           "detail": {
-            "State": ["ERROR", "UNAVAILABLE", "OFFLINE"]
+            "State": [
+              "ERROR",
+              "UNAVAILABLE",
+              "OFFLINE"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1894,10 +2448,16 @@
         "Name": "iot-analytics-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS IoT Analytics Failures.",
         "EventPattern": {
-          "source": ["aws.iotanalytics"],
-          "detail-type": ["IoT Analytics Dataset Lifecycle Notification"],
+          "source": [
+            "aws.iotanalytics"
+          ],
+          "detail-type": [
+            "IoT Analytics Dataset Lifecycle Notification"
+          ],
           "detail": {
-            "state": ["CONTENT_DELIVERY_FAILED"]
+            "state": [
+              "CONTENT_DELIVERY_FAILED"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1929,10 +2489,16 @@
         "Name": "data-lifecycle-manager-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Data Lifecycle Manager Errors.",
         "EventPattern": {
-          "source": ["aws.dlm"],
-          "detail-type": ["DLM Policy State Change"],
+          "source": [
+            "aws.dlm"
+          ],
+          "detail-type": [
+            "DLM Policy State Change"
+          ],
           "detail": {
-            "state": ["ERROR"]
+            "state": [
+              "ERROR"
+            ]
           }
         },
         "State": "ENABLED",
@@ -1964,7 +2530,9 @@
         "Name": "elemental-mediapackage-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Elemental MediaPackage Errors.",
         "EventPattern": {
-          "source": ["aws.mediapackage"],
+          "source": [
+            "aws.mediapackage"
+          ],
           "detail-type": [
             "MediaPackage Input Notification",
             "MediaPackage Key Provider Notification"
@@ -2006,8 +2574,12 @@
         "Name": "elemental-medialive-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Elemental MediaLive Errors.",
         "EventPattern": {
-          "source": ["aws.medialive"],
-          "detail-type": ["MediaLive Channel Alert"]
+          "source": [
+            "aws.medialive"
+          ],
+          "detail-type": [
+            "MediaLive Channel Alert"
+          ]
         },
         "State": "ENABLED",
         "Targets": [
@@ -2038,10 +2610,16 @@
         "Name": "elemental-mediaconvert-error-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS Elemental MediaConvert Errors.",
         "EventPattern": {
-          "source": ["aws.mediaconvert"],
-          "detail-type": ["MediaConvert Job State Change"],
+          "source": [
+            "aws.mediaconvert"
+          ],
+          "detail-type": [
+            "MediaConvert Job State Change"
+          ],
           "detail": {
-            "status": ["ERROR"]
+            "status": [
+              "ERROR"
+            ]
           }
         },
         "State": "ENABLED",
@@ -2073,10 +2651,16 @@
         "Name": "sagemaker-hyperparameter-tuning-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SageMaker HyperParameter Tuning Failures.",
         "EventPattern": {
-          "source": ["aws.sagemaker"],
-          "detail-type": ["SageMaker HyperParameter Tuning Job State Change"],
+          "source": [
+            "aws.sagemaker"
+          ],
+          "detail-type": [
+            "SageMaker HyperParameter Tuning Job State Change"
+          ],
           "detail": {
-            "HyperParameterTuningJobStatus": ["Failed"]
+            "HyperParameterTuningJobStatus": [
+              "Failed"
+            ]
           }
         },
         "State": "ENABLED",
@@ -2108,10 +2692,16 @@
         "Name": "sagemaker-transform-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SageMaker Transform Failures.",
         "EventPattern": {
-          "source": ["aws.sagemaker"],
-          "detail-type": ["SageMaker Transform Job State Change"],
+          "source": [
+            "aws.sagemaker"
+          ],
+          "detail-type": [
+            "SageMaker Transform Job State Change"
+          ],
           "detail": {
-            "TransformJobStatus": ["Failed"]
+            "TransformJobStatus": [
+              "Failed"
+            ]
           }
         },
         "State": "ENABLED",
@@ -2143,10 +2733,16 @@
         "Name": "sagemaker-training-failure-cloudwatch-event",
         "Description": "AWS CloudWatch Event to Send Notification on AWS SNS regarding AWS SageMaker Training Failures.",
         "EventPattern": {
-          "source": ["aws.sagemaker"],
-          "detail-type": ["SageMaker Training Job State Change"],
+          "source": [
+            "aws.sagemaker"
+          ],
+          "detail-type": [
+            "SageMaker Training Job State Change"
+          ],
           "detail": {
-            "TrainingJobStatus": ["Failed"]
+            "TrainingJobStatus": [
+              "Failed"
+            ]
           }
         },
         "State": "ENABLED",

--- a/aws_failure_error_warning_termination_notification_framework_cft.yaml
+++ b/aws_failure_error_warning_termination_notification_framework_cft.yaml
@@ -6,19 +6,21 @@ Description: >-
 Parameters:
   FailureErrorWarningTerminationNotificationSNSTopicEndpoint:
     Description: >-
-      Endpoint for AWS Failure, Error, Warning and Termination Notification SNS Topic.
+      Endpoint for AWS Failure, Error, Warning and Termination Notification SNS
+      Topic.
     Type: String
   FailureErrorWarningTerminationNotificationSNSTopicProtocol:
     Description: >-
-      Protocol for AWS Failure, Error, Warning and Termination Notification SNS Topic.
+      Protocol for AWS Failure, Error, Warning and Termination Notification SNS
+      Topic.
     Type: String
   EnableCloudFormationFailureNotification:
     Description: Option to Enable AWS CloudFormation Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   CloudFormationFailureLambdaCodeS3Bucket:
     Description: >-
@@ -35,459 +37,470 @@ Parameters:
   EnableLambdaFailureNotification:
     Description: Option to Enable AWS Lambda Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableDMSFailureWarningNotification:
     Description: Option to Enable AWS DMS Failure and Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableRDSFailureWarningNotification:
     Description: Option to Enable AWS RDS Failure and Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
+    ConstraintDescription: Select 'YES' or 'NO'
+  EnableRedshiftErrorNotification:
+    Description: Option to Enable AWS Redshift Error Notification.
+    Type: String
+    Default: "YES"
+    AllowedValues:
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableCodeBuildFailureNotification:
     Description: Option to Enable AWS CodeBuild Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableEC2AutoScalingFailureNotification:
     Description: Option to Enable AWS EC2 Auto Scaling Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableBatchFailureNotification:
     Description: Option to Enable AWS Batch Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableCodeDeployFailureNotification:
     Description: Option to Enable AWS CodeDeploy Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableCodePipelineFailureNotification:
     Description: Option to Enable AWS CodePipeline Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableConfigFailureNotification:
     Description: Option to Enable AWS Config Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableEBSFailureNotification:
     Description: Option to Enable AWS EBS Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableGlueFailureNotification:
     Description: Option to Enable AWS Glue Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableEMRFailureNotification:
     Description: Option to Enable AWS EMR Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableEMRErrorNotification:
     Description: Option to Enable AWS EMR Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableECSInstanceTerminationNotification:
     Description: Option to Enable AWS ECS Instance Termination Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableECSTaskTerminationNotification:
     Description: Option to Enable AWS ECS Task Termination Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableEC2InstanceTerminationNotification:
     Description: Option to Enable AWS EC2 Instance Termination Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableEC2SpotInstanceErrorNotification:
     Description: Option to Enable AWS EC2 Spot Instance Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableTrustedAdvisorErrorWarningNotification:
     Description: Option to Enable AWS Trusted Advisor Error and Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableHealthErrorNotification:
     Description: Option to Enable AWS Health Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSMSFailureNotification:
     Description: Option to Enable AWS Server Migration Service Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableStepFunctionsFailureNotification:
     Description: Option to Enable AWS Step Functions Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSSMMaintainanceWindowFailureNotification:
     Description: Option to Enable AWS SSM Maintainance Window Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSSMEC2FailureNotification:
     Description: >-
       Option to Enable AWS SSM EC2 State Manager, Run Command and Automation
       Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSSMComplianceWarningNotification:
     Description: Option to Enable AWS SSM Compliance Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableOpsWorksFailureNotification:
     Description: Option to Enable AWS OpsWorks Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableOpsWorksErrorNotification:
     Description: Option to Enable AWS OpsWorks Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableKMSKeyExpirationWarningNotification:
     Description: Option to Enable AWS KMS Key Expiration Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableMacieWarningNotification:
     Description: Option to Enable AWS Macie Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableGameLiftFailureNotification:
     Description: Option to Enable AWS GameLift Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableTranscribeFailureNotification:
     Description: Option to Enable AWS Transcribe Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSignerFailureNotification:
     Description: Option to Enable AWS Signer Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableDataSyncErrorWarningNotification:
     Description: Option to Enable AWS DataSync Error and Warning Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableIoTAnalyticsFailureNotification:
     Description: Option to Enable AWS IoT Analytics Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableDataLifecycleManagerErrorNotification:
     Description: Option to Enable AWS Data Lifecycle Manager Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableElementalMediaPackageErrorNotification:
     Description: Option to Enable AWS Elemental MediaPackage Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableElementalMediaLiveErrorNotification:
     Description: Option to Enable AWS Elemental MediaLive Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableElementalMediaConvertErrorNotification:
     Description: Option to Enable AWS Elemental MediaConvert Error Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSageMakerHyperParameterTuningFailureNotification:
     Description: Option to Enable AWS SageMaker HyperParameter Tuning Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSageMakerTransformFailureNotification:
     Description: Option to Enable AWS SageMaker Transform Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
   EnableSageMakerTrainingFailureNotification:
     Description: Option to Enable AWS SageMaker Training Failure Notification.
     Type: String
-    Default: 'YES'
+    Default: "YES"
     AllowedValues:
-      - 'YES'
-      - 'NO'
+      - "YES"
+      - "NO"
     ConstraintDescription: Select 'YES' or 'NO'
 Conditions:
-  CreateCloudFormationFailureResources: !Equals 
+  CreateCloudFormationFailureResources: !Equals
     - !Ref EnableCloudFormationFailureNotification
-    - 'YES'
-  CreateLambdaFailureResources: !Equals 
+    - "YES"
+  CreateLambdaFailureResources: !Equals
     - !Ref EnableLambdaFailureNotification
-    - 'YES'
-  CreateDMSFailureWarningResources: !Equals 
+    - "YES"
+  CreateDMSFailureWarningResources: !Equals
     - !Ref EnableDMSFailureWarningNotification
-    - 'YES'
-  CreateRDSFailureWarningResources: !Equals 
+    - "YES"
+  CreateRDSFailureWarningResources: !Equals
     - !Ref EnableRDSFailureWarningNotification
-    - 'YES'
-  CreateCBFailureResources: !Equals 
+    - "YES"
+  CreateRedshiftErrorResources: !Equals
+    - !Ref EnableRedshiftErrorNotification
+    - "YES"
+  CreateCBFailureResources: !Equals
     - !Ref EnableCodeBuildFailureNotification
-    - 'YES'
-  CreateEC2AutoScalingFailureResources: !Equals 
+    - "YES"
+  CreateEC2AutoScalingFailureResources: !Equals
     - !Ref EnableEC2AutoScalingFailureNotification
-    - 'YES'
-  CreateBatchFailureResources: !Equals 
+    - "YES"
+  CreateBatchFailureResources: !Equals
     - !Ref EnableBatchFailureNotification
-    - 'YES'
-  CreateCodeDeployFailureResources: !Equals 
+    - "YES"
+  CreateCodeDeployFailureResources: !Equals
     - !Ref EnableCodeDeployFailureNotification
-    - 'YES'
-  CreateCodePipelineFailureResources: !Equals 
+    - "YES"
+  CreateCodePipelineFailureResources: !Equals
     - !Ref EnableCodePipelineFailureNotification
-    - 'YES'
-  CreateConfigFailureResources: !Equals 
+    - "YES"
+  CreateConfigFailureResources: !Equals
     - !Ref EnableConfigFailureNotification
-    - 'YES'
-  CreateEBSFailureResources: !Equals 
+    - "YES"
+  CreateEBSFailureResources: !Equals
     - !Ref EnableEBSFailureNotification
-    - 'YES'
-  CreateGlueFailureResources: !Equals 
+    - "YES"
+  CreateGlueFailureResources: !Equals
     - !Ref EnableGlueFailureNotification
-    - 'YES'
-  CreateEMRFailureResources: !Equals 
+    - "YES"
+  CreateEMRFailureResources: !Equals
     - !Ref EnableEMRFailureNotification
-    - 'YES'
-  CreateEMRErrorResources: !Equals 
+    - "YES"
+  CreateEMRErrorResources: !Equals
     - !Ref EnableEMRErrorNotification
-    - 'YES'
-  CreateECSInstanceTerminationResources: !Equals 
+    - "YES"
+  CreateECSInstanceTerminationResources: !Equals
     - !Ref EnableECSInstanceTerminationNotification
-    - 'YES'
-  CreateECSTaskTerminationResources: !Equals 
+    - "YES"
+  CreateECSTaskTerminationResources: !Equals
     - !Ref EnableECSTaskTerminationNotification
-    - 'YES'
-  CreateEC2InstanceTerminationResources: !Equals 
+    - "YES"
+  CreateEC2InstanceTerminationResources: !Equals
     - !Ref EnableEC2InstanceTerminationNotification
-    - 'YES'
-  CreateEC2SpotInstanceErrorResources: !Equals 
+    - "YES"
+  CreateEC2SpotInstanceErrorResources: !Equals
     - !Ref EnableEC2SpotInstanceErrorNotification
-    - 'YES'
-  CreateTrustedAdvisorErrorWarningResources: !Equals 
+    - "YES"
+  CreateTrustedAdvisorErrorWarningResources: !Equals
     - !Ref EnableTrustedAdvisorErrorWarningNotification
-    - 'YES'
-  CreateHealthErrorResources: !Equals 
+    - "YES"
+  CreateHealthErrorResources: !Equals
     - !Ref EnableHealthErrorNotification
-    - 'YES'
-  CreateSMSFailureResources: !Equals 
+    - "YES"
+  CreateSMSFailureResources: !Equals
     - !Ref EnableSMSFailureNotification
-    - 'YES'
-  CreateStepFunctionsFailureResources: !Equals 
+    - "YES"
+  CreateStepFunctionsFailureResources: !Equals
     - !Ref EnableStepFunctionsFailureNotification
-    - 'YES'
-  CreateSSMMaintainanceWindowFailureResources: !Equals 
+    - "YES"
+  CreateSSMMaintainanceWindowFailureResources: !Equals
     - !Ref EnableSSMMaintainanceWindowFailureNotification
-    - 'YES'
-  CreateSSMEC2FailureResources: !Equals 
+    - "YES"
+  CreateSSMEC2FailureResources: !Equals
     - !Ref EnableSSMEC2FailureNotification
-    - 'YES'
-  CreateSSMComplianceWarningResources: !Equals 
+    - "YES"
+  CreateSSMComplianceWarningResources: !Equals
     - !Ref EnableSSMComplianceWarningNotification
-    - 'YES'
-  CreateOpsWorksFailureResources: !Equals 
+    - "YES"
+  CreateOpsWorksFailureResources: !Equals
     - !Ref EnableOpsWorksFailureNotification
-    - 'YES'
-  CreateOpsWorksErrorResources: !Equals 
+    - "YES"
+  CreateOpsWorksErrorResources: !Equals
     - !Ref EnableOpsWorksErrorNotification
-    - 'YES'
-  CreateKMSKeyExpirationWarningResources: !Equals 
+    - "YES"
+  CreateKMSKeyExpirationWarningResources: !Equals
     - !Ref EnableKMSKeyExpirationWarningNotification
-    - 'YES'
-  CreateMacieWarningResources: !Equals 
+    - "YES"
+  CreateMacieWarningResources: !Equals
     - !Ref EnableMacieWarningNotification
-    - 'YES'
-  CreateGameLiftFailureResources: !Equals 
+    - "YES"
+  CreateGameLiftFailureResources: !Equals
     - !Ref EnableGameLiftFailureNotification
-    - 'YES'
-  CreateTranscribeFailureResources: !Equals 
+    - "YES"
+  CreateTranscribeFailureResources: !Equals
     - !Ref EnableTranscribeFailureNotification
-    - 'YES'
-  CreateSignerFailureResources: !Equals 
+    - "YES"
+  CreateSignerFailureResources: !Equals
     - !Ref EnableSignerFailureNotification
-    - 'YES'
-  CreateDataSyncErrorWarningResources: !Equals 
+    - "YES"
+  CreateDataSyncErrorWarningResources: !Equals
     - !Ref EnableDataSyncErrorWarningNotification
-    - 'YES'
-  CreateIoTAnalyticsFailureResources: !Equals 
+    - "YES"
+  CreateIoTAnalyticsFailureResources: !Equals
     - !Ref EnableIoTAnalyticsFailureNotification
-    - 'YES'
-  CreateDataLifecycleManagerErrorResources: !Equals 
+    - "YES"
+  CreateDataLifecycleManagerErrorResources: !Equals
     - !Ref EnableDataLifecycleManagerErrorNotification
-    - 'YES'
-  CreateElementalMediaPackageErrorResources: !Equals 
+    - "YES"
+  CreateElementalMediaPackageErrorResources: !Equals
     - !Ref EnableElementalMediaPackageErrorNotification
-    - 'YES'
-  CreateElementalMediaLiveErrorResources: !Equals 
+    - "YES"
+  CreateElementalMediaLiveErrorResources: !Equals
     - !Ref EnableElementalMediaLiveErrorNotification
-    - 'YES'
-  CreateElementalMediaConvertErrorResources: !Equals 
+    - "YES"
+  CreateElementalMediaConvertErrorResources: !Equals
     - !Ref EnableElementalMediaConvertErrorNotification
-    - 'YES'
-  CreateSageMakerHyperParameterTuningFailureResources: !Equals 
+    - "YES"
+  CreateSageMakerHyperParameterTuningFailureResources: !Equals
     - !Ref EnableSageMakerHyperParameterTuningFailureNotification
-    - 'YES'
-  CreateSageMakerTransformFailureResources: !Equals 
+    - "YES"
+  CreateSageMakerTransformFailureResources: !Equals
     - !Ref EnableSageMakerTransformFailureNotification
-    - 'YES'
-  CreateSageMakerTrainingFailureResources: !Equals 
+    - "YES"
+  CreateSageMakerTrainingFailureResources: !Equals
     - !Ref EnableSageMakerTrainingFailureNotification
-    - 'YES'
+    - "YES"
 Resources:
   FailureNotificationSNSTopic:
-    Type: 'AWS::SNS::Topic'
+    Type: "AWS::SNS::Topic"
     Properties:
       TopicName: failure-error-warning-termination-notification-sns-topic
       Subscription:
         - Endpoint: !Ref FailureErrorWarningTerminationNotificationSNSTopicEndpoint
           Protocol: !Ref FailureErrorWarningTerminationNotificationSNSTopicProtocol
   FailureNotificationSNSTopicPolicy:
-    Type: 'AWS::SNS::TopicPolicy'
+    Type: "AWS::SNS::TopicPolicy"
     Properties:
       PolicyDocument:
         Version: 2012-10-17
@@ -496,21 +509,21 @@ Resources:
           - Sid: Sid1
             Effect: Allow
             Principal:
-              AWS: '*'
+              AWS: "*"
             Action:
-              - 'SNS:Publish'
-              - 'SNS:RemovePermission'
-              - 'SNS:SetTopicAttributes'
-              - 'SNS:DeleteTopic'
-              - 'SNS:ListSubscriptionsByTopic'
-              - 'SNS:GetTopicAttributes'
-              - 'SNS:Receive'
-              - 'SNS:AddPermission'
-              - 'SNS:Subscribe'
+              - "SNS:Publish"
+              - "SNS:RemovePermission"
+              - "SNS:SetTopicAttributes"
+              - "SNS:DeleteTopic"
+              - "SNS:ListSubscriptionsByTopic"
+              - "SNS:GetTopicAttributes"
+              - "SNS:Receive"
+              - "SNS:AddPermission"
+              - "SNS:Subscribe"
             Resource: !Ref FailureNotificationSNSTopic
             Condition:
               StringEquals:
-                'AWS:SourceOwner': !Ref 'AWS::AccountId'
+                "AWS:SourceOwner": !Ref "AWS::AccountId"
           - Sid: Sid2
             Effect: Allow
             Principal:
@@ -524,23 +537,23 @@ Resources:
                 - rds.amazonaws.com
                 - s3.amazonaws.com
             Action:
-              - 'SNS:Publish'
+              - "SNS:Publish"
             Resource: !Ref FailureNotificationSNSTopic
       Topics:
         - !Ref FailureNotificationSNSTopic
   CloudFormationFailureLambdaIAMRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Condition: CreateCloudFormationFailureResources
     Properties:
       RoleName: cf-failure-lambda-iam-role
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: ''
+          - Sid: ""
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: "sts:AssumeRole"
       Policies:
         - PolicyName: CloudFormationFailureLambdaFunctionIAMPolicy
           PolicyDocument:
@@ -548,13 +561,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'sns:Publish'
-                  - 'logs:CreateLogStream'
-                  - 'logs:CreateLogGroup'
-                  - 'logs:PutLogEvents'
-                Resource: '*'
+                  - "sns:Publish"
+                  - "logs:CreateLogStream"
+                  - "logs:CreateLogGroup"
+                  - "logs:PutLogEvents"
+                Resource: "*"
   CloudFormationFailureLambdaFunction:
-    Type: 'AWS::Lambda::Function'
+    Type: "AWS::Lambda::Function"
     Condition: CreateCloudFormationFailureResources
     Properties:
       FunctionName: cf-failure-lambda-function
@@ -568,7 +581,7 @@ Resources:
         S3Bucket: !Ref CloudFormationFailureLambdaCodeS3Bucket
         S3Key: !Ref CloudFormationFailureLambdaCodeS3BucketKey
       Handler: aws_cloudformation_failure_notification.lambda_handler
-      Role: !GetAtt 
+      Role: !GetAtt
         - CloudFormationFailureLambdaIAMRole
         - Arn
       Runtime: python3.9
@@ -578,17 +591,17 @@ Resources:
         - Key: Name
           Value: cf-failure-lambda-function
   CFNotificationSNSTopic:
-    Type: 'AWS::SNS::Topic'
+    Type: "AWS::SNS::Topic"
     Condition: CreateCloudFormationFailureResources
     Properties:
       TopicName: cf-notification-sns-topic
       Subscription:
-        - Endpoint: !GetAtt 
+        - Endpoint: !GetAtt
             - CloudFormationFailureLambdaFunction
             - Arn
           Protocol: lambda
   CFNotificationSNSTopicPolicy:
-    Type: 'AWS::SNS::TopicPolicy'
+    Type: "AWS::SNS::TopicPolicy"
     Condition: CreateCloudFormationFailureResources
     Properties:
       PolicyDocument:
@@ -598,43 +611,43 @@ Resources:
           - Sid: Sid1
             Effect: Allow
             Principal:
-              AWS: '*'
+              AWS: "*"
             Action:
-              - 'SNS:Publish'
-              - 'SNS:RemovePermission'
-              - 'SNS:SetTopicAttributes'
-              - 'SNS:DeleteTopic'
-              - 'SNS:ListSubscriptionsByTopic'
-              - 'SNS:GetTopicAttributes'
-              - 'SNS:Receive'
-              - 'SNS:AddPermission'
-              - 'SNS:Subscribe'
+              - "SNS:Publish"
+              - "SNS:RemovePermission"
+              - "SNS:SetTopicAttributes"
+              - "SNS:DeleteTopic"
+              - "SNS:ListSubscriptionsByTopic"
+              - "SNS:GetTopicAttributes"
+              - "SNS:Receive"
+              - "SNS:AddPermission"
+              - "SNS:Subscribe"
             Resource: !Ref CFNotificationSNSTopic
             Condition:
               StringEquals:
-                'AWS:SourceOwner': !Ref 'AWS::AccountId'
+                "AWS:SourceOwner": !Ref "AWS::AccountId"
           - Sid: Sid2
             Effect: Allow
             Principal:
               Service:
                 - cloudformation.amazonaws.com
             Action:
-              - 'SNS:Publish'
+              - "SNS:Publish"
             Resource: !Ref CFNotificationSNSTopic
       Topics:
         - !Ref CFNotificationSNSTopic
   CloudFormationFailureLambdaInvokePermission:
-    Type: 'AWS::Lambda::Permission'
+    Type: "AWS::Lambda::Permission"
     Condition: CreateCloudFormationFailureResources
     Properties:
-      FunctionName: !GetAtt 
+      FunctionName: !GetAtt
         - CloudFormationFailureLambdaFunction
         - Arn
-      Action: 'lambda:InvokeFunction'
+      Action: "lambda:InvokeFunction"
       Principal: sns.amazonaws.com
       SourceArn: !Ref CFNotificationSNSTopic
   LambdaFailureCloudWatchAlarm:
-    Type: 'AWS::CloudWatch::Alarm'
+    Type: "AWS::CloudWatch::Alarm"
     Condition: CreateLambdaFailureResources
     Properties:
       AlarmName: lambda-function-failure-cloudwatch-alarm
@@ -653,7 +666,7 @@ Resources:
       AlarmActions:
         - !Ref FailureNotificationSNSTopic
   DMSInstanceFailureEvent:
-    Type: 'AWS::DMS::EventSubscription'
+    Type: "AWS::DMS::EventSubscription"
     Condition: CreateDMSFailureWarningResources
     Properties:
       SubscriptionName: dms-instance-failure-warning-event
@@ -668,7 +681,7 @@ Resources:
         - Key: Name
           Value: dms-instance-failure-event
   DMSTaskFailureEvent:
-    Type: 'AWS::DMS::EventSubscription'
+    Type: "AWS::DMS::EventSubscription"
     Condition: CreateDMSFailureWarningResources
     Properties:
       SubscriptionName: dms-task-failure-event
@@ -681,7 +694,7 @@ Resources:
         - Key: Name
           Value: dms-task-failure-event
   RDSInstanceFailureEvent:
-    Type: 'AWS::RDS::EventSubscription'
+    Type: "AWS::RDS::EventSubscription"
     Condition: CreateRDSFailureWarningResources
     Properties:
       EventCategories:
@@ -694,7 +707,7 @@ Resources:
       SnsTopicArn: !Ref FailureNotificationSNSTopic
       SourceType: db-instance
   RDSSecurityGroupFailureEvent:
-    Type: 'AWS::RDS::EventSubscription'
+    Type: "AWS::RDS::EventSubscription"
     Condition: CreateRDSFailureWarningResources
     Properties:
       EventCategories:
@@ -702,7 +715,7 @@ Resources:
       SnsTopicArn: !Ref FailureNotificationSNSTopic
       SourceType: db-security-group
   RDSSnapshotFailureEvent:
-    Type: 'AWS::RDS::EventSubscription'
+    Type: "AWS::RDS::EventSubscription"
     Condition: CreateRDSFailureWarningResources
     Properties:
       EventCategories:
@@ -710,7 +723,7 @@ Resources:
       SnsTopicArn: !Ref FailureNotificationSNSTopic
       SourceType: db-snapshot
   RDSClusterFailureEvent:
-    Type: 'AWS::RDS::EventSubscription'
+    Type: "AWS::RDS::EventSubscription"
     Condition: CreateRDSFailureWarningResources
     Properties:
       EventCategories:
@@ -719,8 +732,53 @@ Resources:
         - notification
       SnsTopicArn: !Ref FailureNotificationSNSTopic
       SourceType: db-cluster
+  RedshiftClusterErrorEvent:
+    Type: "AWS::Redshift::EventSubscription"
+    Condition: CreateRedshiftErrorResources
+    Properties:
+      Enabled: true
+      Severity: ERROR
+      SnsTopicArn: !Ref FailureNotificationSNSTopic
+      SourceType: cluster
+      SubscriptionName: aws-redshift-event-subscription-cluster-error-event
+  RedshiftClusterParameterGroupErrorEvent:
+    Type: "AWS::Redshift::EventSubscription"
+    Condition: CreateRedshiftErrorResources
+    Properties:
+      Enabled: true
+      Severity: ERROR
+      SnsTopicArn: !Ref FailureNotificationSNSTopic
+      SourceType: cluster-parameter-group
+      SubscriptionName: aws-redshift-event-subscription-cluster-parameter-group-error-event
+  RedshiftClusterSecurityGroupErrorEvent:
+    Type: "AWS::Redshift::EventSubscription"
+    Condition: CreateRedshiftErrorResources
+    Properties:
+      Enabled: true
+      Severity: ERROR
+      SnsTopicArn: !Ref FailureNotificationSNSTopic
+      SourceType: cluster-security-group
+      SubscriptionName: aws-redshift-event-subscription-cluster-security-group-error-event
+  RedshiftClusterSnapshotErrorEvent:
+    Type: "AWS::Redshift::EventSubscription"
+    Condition: CreateRedshiftErrorResources
+    Properties:
+      Enabled: true
+      Severity: ERROR
+      SnsTopicArn: !Ref FailureNotificationSNSTopic
+      SourceType: cluster-snapshot
+      SubscriptionName: aws-redshift-event-subscription-cluster-snapshot-error-event
+  RedshiftScheduledActionErrorEvent:
+    Type: "AWS::Redshift::EventSubscription"
+    Condition: CreateRedshiftErrorResources
+    Properties:
+      Enabled: true
+      Severity: ERROR
+      SnsTopicArn: !Ref FailureNotificationSNSTopic
+      SourceType: scheduled-action
+      SubscriptionName: aws-redshift-event-subscription-scheduled-action-error-event
   CBFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateCBFailureResources
     Properties:
       Name: cb-failure-cloudwatch-event
@@ -757,7 +815,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   EC2AutoScalingFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateEC2AutoScalingFailureResources
     Properties:
       Name: ec2-autoscaling-failure-cloudwatch-event
@@ -792,7 +850,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   BatchFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateBatchFailureResources
     Properties:
       Name: batch-failure-cloudwatch-event
@@ -829,7 +887,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   CodeDeployFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateCodeDeployFailureResources
     Properties:
       Name: codedeploy-failure-cloudwatch-event
@@ -867,7 +925,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   CodePipelineFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateCodePipelineFailureResources
     Properties:
       Name: codepipeline-failure-cloudwatch-event
@@ -905,7 +963,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   ConfigFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateConfigFailureResources
     Properties:
       Name: config-failure-cloudwatch-event
@@ -942,7 +1000,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   EBSFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateEBSFailureResources
     Properties:
       Name: ebs-failure-cloudwatch-event
@@ -989,7 +1047,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   GlueFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateGlueFailureResources
     Properties:
       Name: glue-failure-cloudwatch-event
@@ -1028,7 +1086,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   EMRFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateEMRFailureResources
     Properties:
       Name: emr-failure-cloudwatch-event
@@ -1072,7 +1130,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   EMRErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateEMRErrorResources
     Properties:
       Name: emr-error-cloudwatch-event
@@ -1106,7 +1164,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   ECSInstanceTerminationCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateECSInstanceTerminationResources
     Properties:
       Name: ecs-instance-termination-cloudwatch-event
@@ -1143,7 +1201,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   ECSTaskTerminationCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateECSTaskTerminationResources
     Properties:
       Name: ecs-task-termination-cloudwatch-event
@@ -1180,7 +1238,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   EC2InstanceTerminationCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateEC2InstanceTerminationResources
     Properties:
       Name: ec2-instance-termination-cloudwatch-event
@@ -1218,7 +1276,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   EC2SpotInstanceErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateEC2SpotInstanceErrorResources
     Properties:
       Name: ec2-spot-instance-error-cloudwatch-event
@@ -1252,7 +1310,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   TrustedAdvisorErrorWarningCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateTrustedAdvisorErrorWarningResources
     Properties:
       Name: trusted-advisor-error-warning-cloudwatch-event
@@ -1290,7 +1348,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   HealthErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateHealthErrorResources
     Properties:
       Name: health-error-cloudwatch-event
@@ -1328,7 +1386,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SMSFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSMSFailureResources
     Properties:
       Name: sms-failure-cloudwatch-event
@@ -1365,7 +1423,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   StepFunctionsFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateStepFunctionsFailureResources
     Properties:
       Name: step-functions-failure-cloudwatch-event
@@ -1404,7 +1462,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SSMMaintainanceWindowFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSSMMaintainanceWindowFailureResources
     Properties:
       Name: ssm-maintainance-window-failure-cloudwatch-event
@@ -1445,7 +1503,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SSMEC2FailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSSMEC2FailureResources
     Properties:
       Name: ssm-ec2-failure-cloudwatch-event
@@ -1489,7 +1547,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SSMComplianceWarningCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSSMComplianceWarningResources
     Properties:
       Name: ssm-compliance-warning-cloudwatch-event
@@ -1526,7 +1584,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   OpsWorksFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateOpsWorksFailureResources
     Properties:
       Name: opsworks-failure-cloudwatch-event
@@ -1574,7 +1632,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   OpsWorksErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateOpsWorksErrorResources
     Properties:
       Name: opsworks-error-cloudwatch-event
@@ -1608,7 +1666,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   KMSKeyExpirationWarningCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateKMSKeyExpirationWarningResources
     Properties:
       Name: kms-key-expiration-warning-cloudwatch-event
@@ -1642,7 +1700,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   MacieWarningCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateMacieWarningResources
     Properties:
       Name: macie-warning-cloudwatch-event
@@ -1676,7 +1734,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   GameLiftFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateGameLiftFailureResources
     Properties:
       Name: gamelift-failure-cloudwatch-event
@@ -1715,7 +1773,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   TranscribeFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateTranscribeFailureResources
     Properties:
       Name: transcribe-failure-cloudwatch-event
@@ -1752,7 +1810,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SignerFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSignerFailureResources
     Properties:
       Name: signer-failure-cloudwatch-event
@@ -1789,7 +1847,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   DataSyncErrorWarningCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateDataSyncErrorWarningResources
     Properties:
       Name: datasync-error-warning-cloudwatch-event
@@ -1830,7 +1888,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   IoTAnalyticsFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateIoTAnalyticsFailureResources
     Properties:
       Name: iot-analytics-failure-cloudwatch-event
@@ -1867,7 +1925,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   DataLifecycleManagerErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateDataLifecycleManagerErrorResources
     Properties:
       Name: data-lifecycle-manager-error-cloudwatch-event
@@ -1904,7 +1962,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   ElementalMediaPackageErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateElementalMediaPackageErrorResources
     Properties:
       Name: elemental-mediapackage-error-cloudwatch-event
@@ -1944,7 +2002,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   ElementalMediaLiveErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateElementalMediaLiveErrorResources
     Properties:
       Name: elemental-medialive-error-cloudwatch-event
@@ -1978,7 +2036,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   ElementalMediaConvertErrorCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateElementalMediaConvertErrorResources
     Properties:
       Name: elemental-mediaconvert-error-cloudwatch-event
@@ -2015,7 +2073,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SageMakerHyperParameterTuningFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSageMakerHyperParameterTuningFailureResources
     Properties:
       Name: sagemaker-hyperparameter-tuning-failure-cloudwatch-event
@@ -2052,7 +2110,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SageMakerTransformFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSageMakerTransformFailureResources
     Properties:
       Name: sagemaker-transform-failure-cloudwatch-event
@@ -2089,7 +2147,7 @@ Resources:
               "AWS Event Resource(s): <resources>"
               "AWS Event Details (minified json string): <detail>"
   SageMakerTrainingFailureCloudWatchEvent:
-    Type: 'AWS::Events::Rule'
+    Type: "AWS::Events::Rule"
     Condition: CreateSageMakerTrainingFailureResources
     Properties:
       Name: sagemaker-training-failure-cloudwatch-event

--- a/terraform-usage-example.tf
+++ b/terraform-usage-example.tf
@@ -3,6 +3,12 @@ module "aws-failure-error-warning-termination-notification-framework" {
   failure_error_warning_termination_notification_sns_topic_protocol = "email"
   failure_error_warning_termination_notification_sns_topic_endpoint = "abc.xyz@gmail.com"
 
+  # Following is an optional variable.
+  # It is used to provide a list of AWS Lambda function names to monitor for failures.
+  # If not provided, it will fetch all AWS Lambda function names.
+  # Only works if enable_lambda_failure_notification variable is set to true.
+  # e.g., lambda_function_names = ["function-1", "function-2"]
+
   # Enabled
   enable_cloudformation_failure_notification          = true
   enable_lambda_failure_notification                  = true
@@ -20,6 +26,7 @@ module "aws-failure-error-warning-termination-notification-framework" {
 
   # Not Enabled
   enable_dms_failure_warning_notification                       = false
+  enable_redshift_error_notification                            = false
   enable_code_build_failure_notification                        = false
   enable_batch_failure_notification                             = false
   enable_code_deploy_failure_notification                       = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,6 +20,12 @@ variable "enable_lambda_failure_notification" {
   default     = false
 }
 
+variable "lambda_function_names" {
+  description = "List of AWS Lambda function names to monitor for failures."
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_dms_failure_warning_notification" {
   description = "Option to Enable AWS DMS Failure and Warning Notification."
   type        = string
@@ -28,6 +34,12 @@ variable "enable_dms_failure_warning_notification" {
 
 variable "enable_rds_failure_warning_notification" {
   description = "Option to Enable AWS RDS Failure and Warning Notification."
+  type        = string
+  default     = false
+}
+
+variable "enable_redshift_error_notification" {
+  description = "Option to Enable AWS Redshift Error Notification."
   type        = string
   default     = false
 }


### PR DESCRIPTION
Changes:
- Add AWS Redshift monitoring for errors and add the capability to create AWS CloudWatch alarms for all or specific AWS Lambda functions for failures.
- Update usage example for Terraform to accomodate for new changes related to monitoring and alerting of AWS Redshift and AWS Lambda.
- Add AWS Redshift monitoring for errors and refactor the code.
- Update README.md w.r.t new changes related to monitoring and alerting of AWS Redshift and AWS Lambda.